### PR TITLE
Allow config of bugsnag hostname and release_stage

### DIFF
--- a/config/initializers/error_tracker.rb
+++ b/config/initializers/error_tracker.rb
@@ -1,7 +1,9 @@
 if ENV["BUGSNAG_KEY"]
   Bugsnag.configure do |config|
     config.api_key = ENV["BUGSNAG_KEY"]
-    config.notify_release_stages = %w(stage production)
+    config.hostname = ENV['BUGSNAG_HOSTNAME'] if ENV['BUGSNAG_HOSTNAME']
+    config.release_stage = ENV['BUGSNAG_RELEASE_STAGE'] if ENV['BUGSNAG_RELEASE_STAGE']
+    config.notify_release_stages = ["dev", "stage", "prod"]
   end
 elsif ENV["SENTRY_KEY"]
   require 'raven'


### PR DESCRIPTION
Linked PR: https://github.com/PLOS-Formulas/lagotto-formula/pull/21

Because these don't automatically get set correctly inside containers.

This is based on the thing @benjaminkreen found in Jackalope and emailed us all about