### PR TITLE
Fix swagger docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       DATABASE_URL: mysql2://root:password@db:3306/alm?pool=5&timeout=5000&encoding=utf8mb4
       REDIS_URL: redis://redis:6379/0
       SOLR_URL: http://solr-mega-dev.soma.plos.org/solr/journals_dev/select
+      SERVERNAME: "localhost:8080"
     command: ["docker/start.sh", "db:3306"]
     ports:
       - 9292:9292

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -4,4 +4,5 @@
 
 docker/wait-for.sh -t 30 $1
 bundle exec rake db:create db:migrate
+bundle exec rake swagger:docs
 bundle exec puma -C config/puma.rb


### PR DESCRIPTION
For https://jira.plos.org/jira/browse/ALM-1045

fixes /api in docker setup.

But it's still broken in non docker envs, but that's not a regression, since prod is currently broken in the same way http://alm.plos.org/api

to test:

* `docker-compose build`
* `docker-compose up`
* browse to http://localhost:8080/api