### PR TITLE
ROUT-487 notify via POST instead of GET

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ irb(main):020:0> EnvConfig.config_for "SUBSCRIBERS__"
 
 Now tell lagotto to fetch new data. This will trigger a notification of the configured subscriber. Watch for an entry from the test_subscriber container in the  docker-compose logs:
 ```
-test_subscriber_1  | 192.168.16.5 - - [29/Oct/2019:23:38:19 +0000] "GET /notify-me-please?doi=10.1371%2Fjournal.pcbi.0010052&milestone=1 HTTP/1.1" 200 22 "-" "Faraday v0.9.2" "-"
+test_subscriber_1  | 192.168.16.5 - - [29/Oct/2019:23:38:19 +0000] "POST /notify-me-please HTTP/1.1" 200 22 "-" "Faraday v0.9.2" "-"
 ```
 
 ```ruby

--- a/lib/subscribers.rb
+++ b/lib/subscribers.rb
@@ -11,7 +11,7 @@ class Subscribers
       hit = milestones.select{ |m| range.include?(m) }.last
       if hit
         Rails.logger.info("Notifying subscriber: #{{url: s[:url], doi: doi, milestone: hit}}")
-        resp = Faraday.get(s[:url], doi: doi, milestone: hit)
+        resp = Faraday.post(s[:url], doi: doi, milestone: hit)
         Rails.logger.info("Response from subscriber: #{resp.inspect}")
       end
     end

--- a/spec/lib/subscribers_spec.rb
+++ b/spec/lib/subscribers_spec.rb
@@ -20,20 +20,20 @@ describe Subscribers, vcr: false, focus: true do
       end
 
       it 'notifies subscribers' do
-        expect(Faraday).to receive(:get).with(@subscriber_url, {doi: @article_doi, milestone: 1})
+        expect(Faraday).to receive(:post).with(@subscriber_url, {doi: @article_doi, milestone: 1})
         Subscribers.notify(@article_doi, @citation_source, 0, 14)
       end
 
       context 'multiple milestones were passed' do
         it 'uses the last milestone that was passed' do
-          expect(Faraday).to receive(:get).with(@subscriber_url, {doi: @article_doi, milestone: 15})
+          expect(Faraday).to receive(:post).with(@subscriber_url, {doi: @article_doi, milestone: 15})
           Subscribers.notify(@article_doi, @citation_source, 0, 16)
         end
       end
 
       context 'milestone is exactly the new count' do
         it 'notifies' do
-          expect(Faraday).to receive(:get).with(@subscriber_url, {doi: @article_doi, milestone: 1}).exactly(:once)
+          expect(Faraday).to receive(:post).with(@subscriber_url, {doi: @article_doi, milestone: 1}).exactly(:once)
           Subscribers.notify(@article_doi, @citation_source, 0, 1)
         end
       end


### PR DESCRIPTION
We can change this now before anything uses it.