### PR TITLE
ALM-1082 patch privilege escalation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -99,14 +99,17 @@ class UsersController < ApplicationController
   private
 
   def safe_params
-    params.require(:user).permit(:name,
-                                 :email,
-                                 :password,
-                                 :password_confirmation,
-                                 :subscribe,
-                                 :unsubscribe,
-                                 :role,
-                                 :publisher_id,
-                                 :authentication_token)
+    allowed_params = [
+      :name,
+      :email,
+      :password,
+      :password_confirmation,
+      :subscribe,
+      :unsubscribe,
+      :publisher_id,
+      :authentication_token
+    ]
+    allowed_params << :role if current_user.try(:is_admin?)
+    params.require(:user).permit(allowed_params)
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - db
       - redis
     environment:
+      MEMCACHE_SERVERS: memcached
       DATABASE_URL: mysql2://root:password@db:3306/alm?pool=5&timeout=5000&encoding=utf8mb4
       REDIS_URL: redis://redis:6379/0
       SOLR_URL: http://solr-mega-dev.soma.plos.org/solr/journals_dev/select
@@ -59,6 +60,8 @@ services:
     command: [ "nginx", "-g", "daemon off;" ]
     depends_on:
       - appserver
+  memcached:
+    image: memcached:1.5.20
 
 volumes:
   railsassets:

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe UsersController, :type => :controller do
+
+  describe ".safe_params" do
+    context "with admin current user" do
+      it "returns params with role key" do
+        controller.stub(:current_user) { FactoryGirl.create(:admin_user) }
+        controller.params[:user] = {role: 'admin'}
+        expect(controller.send(:safe_params).has_key?(:role)).to be true
+      end
+    end
+
+    context "with non-admin current user" do
+      it "returns params without role key" do
+        controller.stub(:current_user) { FactoryGirl.create(:user) }
+        controller.params[:user] = { role: 'admin' }
+        expect(controller.send(:safe_params).has_key?(:role)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
This prevents non-admins from setting role on a user. Other original concerns I investigated were:

`Authenticable#authenticate_user_from_token_param!` because it seems like we allow users to set their own api tokens and was worried a user could use that to impersonate someone. But we only authenticate that way in some api reads, and it doesn't set a session.

`UsersController#destroy` I originally thought this was open but access control is defined in `ability.rb` and restricted by `load_and_authorize_resource`. An odd side effect is that `@user` gets clobbered left and right since CanCan (the auth library) tries to set it but then the controller has its own ideas.

There's a lingering `#update_password` that is public in the users controller, but not defined in the routes so I didn't look at it too hard. 



