### PR TITLE
Alm 1008 fix login

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,9 +4,9 @@ require 'rouge'
 module ApplicationHelper
   def login_link
     case ENV['OMNIAUTH']
-    when "cas" then link_to "Sign in with PLOS ID", user_omniauth_authorize_path(:cas), :id => "sign_in"
-    when "github" then link_to "Sign in with Github", user_omniauth_authorize_path(:github), :id => "sign_in"
-    when "orcid" then link_to "Sign in with ORCID", user_omniauth_authorize_path(:orcid), :id => "sign_in"
+    when "cas" then link_to "Sign in with PLOS ID", user_cas_omniauth_authorize_path, :id => "sign_in"
+    when "github" then link_to "Sign in with Github", user_github_omniauth_authorize_path, :id => "sign_in"
+    when "orcid" then link_to "Sign in with ORCID", user_orcid_omniauth_authorize_path, :id => "sign_in"
     else
       form_tag "/users/auth/persona/callback", id: "persona_form", class: "navbar-form" do
         hidden_field_tag('assertion') +

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -18,11 +18,11 @@
   <% end %>
 
   <% if ENV['OMNIAUTH'] == "cas" %>
-    <%= link_to "Sign in with PLOS ID", user_omniauth_authorize_path(:cas), class: "btn btn-info" %>
+    <%= link_to "Sign in with PLOS ID", user_cas_omniauth_authorize_path, class: "btn btn-info" %>
   <% elsif ENV['OMNIAUTH'] == "github" %>
-    <%= link_to "Sign in with Github", user_omniauth_authorize_path(:github), class: "btn btn-info" %>
+    <%= link_to "Sign in with Github", user_github_omniauth_authorize_path, class: "btn btn-info" %>
   <% elsif ENV['OMNIAUTH'] == "orcid" %>
-    <%= link_to "Sign in with ORCID", user_omniauth_authorize_path(:orcid), class: "btn btn-info" %>
+    <%= link_to "Sign in with ORCID", user_orcid_omniauth_authorize_path, class: "btn btn-info" %>
   <% else %>
     <%= form_tag '/users/auth/persona/callback', :id => 'persona_form' do %>
       <%= hidden_field_tag('assertion') %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       SUBSCRIBERS__0__MILESTONES__0: 1
       SUBSCRIBERS__0__MILESTONES__1: 15
       SUBSCRIBERS__0__URL: "http://test_subscriber:9055/notify-me-please"
+      OMNIAUTH: cas
+      CAS_URL: https://register.plos.org/cas
     command: ["docker/start.sh", "db:3306"]
     ports:
       - 9292:9292


### PR DESCRIPTION
Our local development did not exercise the same login path that we use in production.  This hid some broken helpers that broke the front page of the app.  This fixes the helpers and instructions docker-compose to use CAS authentication like we do in prod.  To test:

1. `docker-compose down -v && docker-compose up --build`
2. click on "Sign in with PLOS ID".  It should take you to PLOS' CAS login form.
3. sign in and get redirected back to ALM
